### PR TITLE
Fix ddns IP parsing and robust screenshot

### DIFF
--- a/bin/ddns
+++ b/bin/ddns
@@ -7,10 +7,15 @@ TTL=60
 # Load system hostname setting
 HOSTNAME=$(hostnamectl hostname)
 
-# Fetch the current public IP address
+# Fetch the current public IP address.  Some ipinfo endpoints return JSON
+# while others return just the IP string.  Attempt to parse JSON first and
+# fall back to the raw value if parsing fails.
 IPINFO=$(curl -s https://ipinfo.io/what-is-my-ip)
-
-IP=$(echo $IPINFO | jq '.ip' | sed 's/"//g')
+if IP=$(echo "$IPINFO" | jq -r '.ip' 2>/dev/null); then
+  :
+else
+  IP=$(echo "$IPINFO" | tr -d '\n')
+fi
 
 #validate IP address (makes sure Route 53 doesn't get updated with a malformed payload)
 if [[ ! $IP =~ ^[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then

--- a/bin/screenshot
+++ b/bin/screenshot
@@ -2,6 +2,6 @@
 
 timestamp="$(date +%Y%m%d%H%M%S)"
 targetbase="$HOME/.local/screenshots"
-mkdir -p $targetbase
-[ -d $targetbase ] || exit 1
-scrot $targetbase/$timestamp.png
+mkdir -p "$targetbase"
+[ -d "$targetbase" ] || exit 1
+scrot "$targetbase/$timestamp.png"

--- a/bin/start-zellij
+++ b/bin/start-zellij
@@ -1,6 +1,10 @@
-if command -v zellij-runner &> /dev/null;
-then
-  ZELLIJ_RUNNER_LAYOUTS_DIR=${HOME}/.config/zellij/layouts ZELLIJ_RUNNER_BANNERS_DIR=${HOME}/.config/zellij/banners ZELLIJ_RUNNER_ROOT_DIR=${HOME}/dev/ /home/zenuncl/.cargo/bin/zellij-runner
+#!/usr/bin/env bash
+
+if command -v zellij-runner &> /dev/null; then
+  ZELLIJ_RUNNER_LAYOUTS_DIR="${HOME}/.config/zellij/layouts" \
+  ZELLIJ_RUNNER_BANNERS_DIR="${HOME}/.config/zellij/banners" \
+  ZELLIJ_RUNNER_ROOT_DIR="${HOME}/dev" \
+  zellij-runner
 else
   zellij attach
 fi


### PR DESCRIPTION
## Summary
- handle JSON or plain output when fetching IP in `ddns`
- quote paths in `screenshot` script

## Testing
- `bash -n bin/ddns`
- `bash -n bin/start-zellij`
- `bash -n bin/screenshot`


------
https://chatgpt.com/codex/tasks/task_e_684446b9e198832f8c38c561743c18f3