### PR TITLE
Fix typo in skywalker theme

### DIFF
--- a/zsh/themes/skywalker.zsh-theme
+++ b/zsh/themes/skywalker.zsh-theme
@@ -73,7 +73,7 @@ rev_parse_find() {
     done
     return 1
 }
-# Get development envrioment
+# Get development environment
 
 iscommand() { command -v "$1" > /dev/null; }
 prompt_node_version() {


### PR DESCRIPTION
## Summary
- fix a typo in `skywalker.zsh-theme`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684449dbc9c4832fba50d25e81cd6090