### PR TITLE
Fix typo in init script comment

### DIFF
--- a/setup/system/00-init.sh
+++ b/setup/system/00-init.sh
@@ -3,7 +3,7 @@
 # Init setup to the machine, Default now support Debian and Arch Linux
 set -e
 
-# Veriables
+# Variables
 DEFAULT_PKGS=("sudo" "git" "zsh" "vim" "neovim" "curl" "wget" "tmux" "fasd" "ca-certificates" "gnupg" "net-tools" "sshpass" "cifs-utils" "unzip" "lynx" "traceroute" "fail2ban" "iptables")
 ARCH_PKGS=("base-devel" "openssh" "bind" "qemu-base" "python" "python-pip" "python-virtualenv" "python-pipx")
 DEB_PKGS=("build-essential" "openssh-server" "dnsutils" "qemu-utils" "python3" "python3-pip" "python3-virtualenv")


### PR DESCRIPTION
## Summary
- fix comment in system init script

## Testing
- `bash -n setup/system/00-init.sh`


------
https://chatgpt.com/codex/tasks/task_e_68444b0ab228832f9bee2056db944aa6